### PR TITLE
Non-strings converted before putting in Mongo

### DIFF
--- a/RGZcatalogCode/RGZcatalog.py
+++ b/RGZcatalogCode/RGZcatalog.py
@@ -7,7 +7,7 @@ AllWISE and SDSS catalogs.
 import logging, urllib2, time, argparse, json
 import pymongo
 import numpy as np
-import StringIO, gzip, ast
+import StringIO, gzip
 from astropy.io import fits
 from astropy import wcs, coordinates as coord, units as u
 
@@ -99,7 +99,7 @@ def RGZcatalog():
                 
                 #find IR counterpart from consensus data, if present
                 w = wcs.WCS(fits.getheader(fits_loc, 0)) #gets pixel-to-WCS conversion from header
-                ir_coords = ast.literal_eval(consensusObject['ir_peak'])
+                ir_coords = consensusObject['ir_peak']
                 if ir_coords == (-99, -99):
                     ir_pos = None
                     wise_match = None
@@ -117,7 +117,7 @@ def RGZcatalog():
                     logging.info('IR counterpart found')
                     entry['consensus'].update({'IR_ra':ir_pos.ra.deg, 'IR_dec':ir_pos.dec.deg})
                 else:
-                    logging.info('No IR conterpart found')
+                    logging.info('No IR counterpart found')
 
                 #if an IR peak exists, search AllWISE and SDSS for counterparts
                 if ir_pos:

--- a/RGZcatalogCode/updateConsensus.py
+++ b/RGZcatalogCode/updateConsensus.py
@@ -7,8 +7,6 @@ from pymongo import MongoClient
 import csv
 from ast import literal_eval
 
-csvPath = '/Users/willettk/Astronomy/Research/GalaxyZoo/rgz-analysis/csv/consensus_rgz_first_75.csv'
-
 def updateConsensus(csvPath):
 
     logging.basicConfig(filename='RGZcatalog.log', level=logging.DEBUG, format='%(asctime)s %(message)s')
@@ -31,9 +29,6 @@ def updateConsensus(csvPath):
                 except (ValueError,SyntaxError) as e:
                     entry_typed = str(entry[field])
                 row[field] = entry_typed
-            test.insert(row)
+            consensus.insert(row)
 
-        logging.info('%i entries added to test collection', test.count())
-
-if __name__ == "__main__":
-    updateConsensus(csvPath)
+        logging.info('%i entries added to consensus collection', consensus.count())

--- a/RGZcatalogCode/updateConsensus.py
+++ b/RGZcatalogCode/updateConsensus.py
@@ -17,12 +17,9 @@ def updateConsensus(csvPath):
 
     with open(csvPath, 'r') as csvFile:
         
-        #db = MongoClient()['radio']
-        #db.drop_collection('consensus')
-        #consensus = db['consensus']
-        db = MongoClient()['platypus']
-        db.drop_collection('test')
-        test = db['test']
+        db = MongoClient()['radio']
+        db.drop_collection('consensus')
+        consensus = db['consensus']
 
         consensusDict = csv.DictReader(csvFile)
         header = ['zooniverse_id', 'first_id', 'n_users', 'n_total', 'consensus_level', 'n_radio', 'label', 'bbox', 'ir_peak']

--- a/RGZcatalogCode/updateConsensus.py
+++ b/RGZcatalogCode/updateConsensus.py
@@ -5,6 +5,9 @@ Updates the consensus database in Mongo so that new entries may be added to the 
 import logging
 from pymongo import MongoClient
 import csv
+from ast import literal_eval
+
+csvPath = '/Users/willettk/Astronomy/Research/GalaxyZoo/rgz-analysis/csv/consensus_rgz_first_75.csv'
 
 def updateConsensus(csvPath):
 
@@ -14,16 +17,26 @@ def updateConsensus(csvPath):
 
     with open(csvPath, 'r') as csvFile:
         
-        db = MongoClient()['radio']
-        db.drop_collection('consensus')
-        consensus = db['consensus']
+        #db = MongoClient()['radio']
+        #db.drop_collection('consensus')
+        #consensus = db['consensus']
+        db = MongoClient()['platypus']
+        db.drop_collection('test')
+        test = db['test']
 
         consensusDict = csv.DictReader(csvFile)
         header = ['zooniverse_id', 'first_id', 'n_users', 'n_total', 'consensus_level', 'n_radio', 'label', 'bbox', 'ir_peak']
         for entry in consensusDict:
             row = {}
             for field in header:
-                row[field] = entry[field]
-            consensus.insert(row)
+                try:
+                    entry_typed = literal_eval(entry[field])
+                except (ValueError,SyntaxError) as e:
+                    entry_typed = str(entry[field])
+                row[field] = entry_typed
+            test.insert(row)
 
-        logging.info('%i entries added to consensus collection', consensus.count())
+        logging.info('%i entries added to test collection', test.count())
+
+if __name__ == "__main__":
+    updateConsensus(csvPath)

--- a/python/consensus.py
+++ b/python/consensus.py
@@ -900,11 +900,8 @@ def run_sample(survey,update=True,subset=None,do_plot=False):
                 try:
                     fc.write('{0},{1},{2:4d},{3:4d},{4:.3f},{5:2d},{6},"{7}","{8}"\n'.format( 
                             cons['zid'],cons['source'],
-                            cons['n_users'],cons['n_total'],
-                            cons['consensus_level'],
-                            len(ans['xmax']),
-                            alpha(ans['ind']),
-                            bbox_unravel(ans['bbox']),ir_peak
+                            cons['n_users'],cons['n_total'],cons['consensus_level'],
+                            len(ans['xmax']),alphabet(ans['ind']),bbox_unravel(ans['bbox']),ir_peak
                             )
                     )
                 except KeyError:
@@ -970,7 +967,7 @@ def force_csv_update(survey='first',suffix=''):
                     gal['n_total'],
                     gal['n_users'] * 1./gal['n_total'],
                     len(ans['xmax']),
-                    alpha(ans['ind']),
+                    alphabet(ans['ind']),
                     bbox_unravel(ans['bbox']),
                     ir_peak
                     )
@@ -992,11 +989,18 @@ def bbox_unravel(bbox):
 
     return bboxes
 
-def alpha(i):
+def alphabet(i):
 
     from string import letters
 
-    # Return a letter of the alphabet for a given integer
+    # Return a letter (or set of duplicated letters) of the alphabet for a given integer
+    # For i > 25, letters begin multiplying:    alphabet(0) = 'a' 
+    #                                           alphabet(1) = 'b'
+    #                                           ...
+    #                                           alphabet(25) = 'z'
+    #                                           alphabet(26) = 'aa'
+    #                                           alphabet(27) = 'bb'
+    #                                           ...
     #
     lowercase = letters[26:]
     
@@ -1004,7 +1008,7 @@ def alpha(i):
         letter = letters[26:][i % 26]*int(i/26 + 1)
         return letter
     except TypeError:
-        raise AssertionError("Index must be integer between 0 and 25")
+        raise AssertionError("Index must be an integer")
 
 def update_experts(classifications): 
 


### PR DESCRIPTION
All the fields being put into the `consensus` database in Mongo were being passed as strings. Among other things, that makes it impossible to do searches on numerical values in Mongo. 

This code changes the input by using `literal_eval`, but I don't know if passing things back out as ints, floats, or lists will break other parts of RGZcatalogCode. @afgaron - could you review this and assess whether it's an acceptable change?